### PR TITLE
fix: 修复按照图片添加日期降序排列的问题

### DIFF
--- a/Sources/AnyImageKit/Picker/Util/PickerManager+Album.swift
+++ b/Sources/AnyImageKit/Picker/Util/PickerManager+Album.swift
@@ -13,13 +13,13 @@ extension PickerManager {
     private func createFetchOptions() -> PHFetchOptions {
         let fetchOptions = PHFetchOptions()
         if !options.selectOptions.mediaTypes.contains(.video) {
-            fetchOptions.predicate = NSPredicate(format: "mediaType == %ld", PHAssetMediaType.image.rawValue)
+            fetchOptions.predicate = NSPredicate(format: "mediaType != %ld", PHAssetMediaType.video.rawValue)
         }
         if !options.selectOptions.mediaTypes.contains(.image) {
-            fetchOptions.predicate = NSPredicate(format: "mediaType == %ld", PHAssetMediaType.video.rawValue)
+            fetchOptions.predicate = NSPredicate(format: "mediaType != %ld", PHAssetMediaType.image.rawValue)
         }
         if options.orderByDate == .desc {
-            let sortDescriptor = NSSortDescriptor(key: "creationDate", ascending: false)
+            let sortDescriptor = NSSortDescriptor(key: "mediaType", ascending: false)
             fetchOptions.sortDescriptors = [sortDescriptor]
         }
         return fetchOptions


### PR DESCRIPTION
 `PickerOptionsInfo` 中的 `orderByDate` 属性，默认的升序排列`asc`是按照图片的**添加时间**，并非创建时间，所以降序排列`desc`也应按照**添加时间**。
但是`PHAsset`中没有**添加时间**，经测试可以通过`mediaType`作为排序字段和 `mediaType != %ld` 谓词一起使用来实现与系统相册一样的按照添加时间升序或降序排列。