### PR TITLE
模仿微信，点底部预览时，只预览选中图片，点选相册内图片时，预览所有图片

### DIFF
--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -451,7 +451,9 @@ extension AssetPickerViewController {
         controller.currentIndex = asset.selectedNum - 1
         controller.dataSource = self
         controller.delegate = self
-        manager.previewAll = false
+        if !manager.options.previewAll {
+            manager.previewAll = false
+        }
         present(controller, animated: true, completion: nil)
         trackObserver?.track(event: .pickerPreview, userInfo: [:])
     }

--- a/Sources/AnyImageKit/Picker/Controller/PhotoPreviewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/PhotoPreviewController.swift
@@ -244,6 +244,7 @@ extension PhotoPreviewController {
         view.addSubview(indexView)
         setupLayout()
         setBar(hidden: true, animated: false, isNormal: false)
+        navigationBar.selectButton.isUserInteractionEnabled = manager.previewAll
     }
     
     /// 设置视图布局

--- a/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
+++ b/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
@@ -54,7 +54,7 @@ public struct PickerOptionsInfo {
     public var selectionTapAction: PickerSelectionTapAction = .preview
     
     /// preview all photo
-    /// - Deault: trueß
+    /// - Deault: true
     public var previewAll = true
     
     /// Order by date

--- a/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
+++ b/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
@@ -53,6 +53,10 @@ public struct PickerOptionsInfo {
     /// - Default: Preview
     public var selectionTapAction: PickerSelectionTapAction = .preview
     
+    /// preview all photo
+    /// - Deault: trueß
+    public var previewAll = true
+    
     /// Order by date
     /// - Default: ASC
     public var orderByDate: Sort = .asc

--- a/Sources/AnyImageKit/Picker/Util/PickerManager.swift
+++ b/Sources/AnyImageKit/Picker/Util/PickerManager.swift
@@ -25,7 +25,7 @@ final class PickerManager {
     
     var useOriginalImage: Bool = false
     
-    public var previewAll: Bool = false
+    public var previewAll: Bool = true
     
     /// 已选中的资源
     private(set) var selectedAssets: [Asset] = []

--- a/Sources/AnyImageKit/Picker/Util/PickerManager.swift
+++ b/Sources/AnyImageKit/Picker/Util/PickerManager.swift
@@ -25,6 +25,8 @@ final class PickerManager {
     
     var useOriginalImage: Bool = false
     
+    public var previewAll: Bool = false
+    
     /// 已选中的资源
     private(set) var selectedAssets: [Asset] = []
     /// 获取失败的资源

--- a/Sources/AnyImageKit/Picker/View/PickerPreviewIndexView.swift
+++ b/Sources/AnyImageKit/Picker/View/PickerPreviewIndexView.swift
@@ -73,12 +73,20 @@ final class PickerPreviewIndexView: UIView {
     
     private func didSetCurrentIndex() {
         isHidden = manager.selectedAssets.isEmpty
-        if let idx = manager.selectedAssets.firstIndex(where: { $0.idx == currentIndex }) {
+        var _idx = manager.selectedAssets.firstIndex(where: { $0.selectedNum - 1 == currentIndex })
+        if manager.previewAll {
+            _idx = manager.selectedAssets.firstIndex(where: { $0.idx == currentIndex })
+        }
+        if let idx = _idx {
             let indexPath = IndexPath(item: idx, section: 0)
             collectionView.reloadItems(at: [indexPath])
             collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
         }
-        if let idx = manager.selectedAssets.firstIndex(where: { $0.idx == lastIdx }) {
+        _idx = manager.selectedAssets.firstIndex(where: { $0.selectedNum - 1 == lastIdx })
+        if manager.previewAll {
+            _idx = manager.selectedAssets.firstIndex(where: { $0.idx == lastIdx })
+        }
+        if let idx = _idx {
             collectionView.reloadItems(at: [IndexPath(item: idx, section: 0)])
         }
     }
@@ -115,7 +123,11 @@ extension PickerPreviewIndexView {
     private func selectItemAtFirstTime() {
         if !isFirst { return }
         isFirst = false
-        if let idx = manager.selectedAssets.firstIndex(where: { $0.idx == currentIndex }) {
+        var _idx = manager.selectedAssets.firstIndex(where: { $0.idx == currentIndex })
+        if !manager.previewAll {
+            _idx = manager.selectedAssets.firstIndex(where: { $0.selectedNum - 1 == currentIndex })
+        }
+        if let idx = _idx {
             let indexPath = IndexPath(item: idx, section: 0)
             collectionView.reloadItems(at: [indexPath])
             collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
@@ -135,7 +147,11 @@ extension PickerPreviewIndexView: UICollectionViewDataSource {
         let asset = manager.selectedAssets[indexPath.item]
         cell.setContent(asset, manager: manager, animated: false, isPreview: true)
         cell.selectButton.isHidden = true
-        cell.boxCoverView.isHidden = asset.idx != currentIndex
+        if manager.previewAll {
+            cell.boxCoverView.isHidden = asset.idx != currentIndex
+        } else {
+            cell.boxCoverView.isHidden = asset.selectedNum - 1 != currentIndex
+        }
         return cell
     }
 }
@@ -144,6 +160,10 @@ extension PickerPreviewIndexView: UICollectionViewDataSource {
 extension PickerPreviewIndexView: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        delegate?.pickerPreviewIndexView(self, didSelect: manager.selectedAssets[indexPath.item].idx)
+        if manager.previewAll {
+            delegate?.pickerPreviewIndexView(self, didSelect: manager.selectedAssets[indexPath.item].idx)
+            return
+        }
+        delegate?.pickerPreviewIndexView(self, didSelect: manager.selectedAssets[indexPath.item].selectedNum - 1)
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/626401/209090429-85887a0c-50f4-4143-bb49-492c1093c898.png)
最近业务需求，要模仿微信：
点击底部预览时，只能预览已选中的图片
点选相册内照片时，可以预览所有图片

由于新加的功能，可能并非所有用户都需要，所以加了一个开关
默认是跟原库效果保持一致
`PickerOptionsInfo: previewAll`