### PR TITLE
Fix a reference to self

### DIFF
--- a/Example/Controller/HomeViewController.swift
+++ b/Example/Controller/HomeViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class HomeViewController: UITableViewController {
     
-    private var versionButton: UIButton = {
+    private lazy var versionButton: UIButton = {
         let view = UIButton(frame: .zero)
         if let info = Bundle.main.infoDictionary, let version = info["CFBundleShortVersionString"] as? String {
             view.titleLabel?.font = UIFont.systemFont(ofSize: 12, weight: .medium)


### PR DESCRIPTION
Hi,

This PR marks the `versionButton` property as `lazy` to resolve the following compiler warning:

```
'self' refers to the method 'HomeViewController.self', which may be unexpected
```