### PR TITLE
Fix access control levels

### DIFF
--- a/Sources/AnyImageKit/Capture/Controller/ImageCaptureController.swift
+++ b/Sources/AnyImageKit/Capture/Controller/ImageCaptureController.swift
@@ -64,7 +64,7 @@ open class ImageCaptureController: AnyImageNavigationController {
 
 extension ImageCaptureController {
     
-    open func update(options: CaptureOptionsInfo) {
+    public func update(options: CaptureOptionsInfo) {
         guard viewControllers.isEmpty || enableForceUpdate else {
             return
         }

--- a/Sources/AnyImageKit/Editor/Controller/ImageEditorController.swift
+++ b/Sources/AnyImageKit/Editor/Controller/ImageEditorController.swift
@@ -98,7 +98,7 @@ open class ImageEditorController: AnyImageNavigationController {
 
 extension ImageEditorController {
     
-    open func update(photo resource: EditorPhotoResource, options: EditorPhotoOptionsInfo) {
+    public func update(photo resource: EditorPhotoResource, options: EditorPhotoOptionsInfo) {
         guard viewControllers.isEmpty || enableForceUpdate else {
             return
         }
@@ -109,7 +109,7 @@ extension ImageEditorController {
         viewControllers = [rootViewController]
     }
     
-    open func update(video resource: EditorVideoResource, placeholderImage: UIImage?, options: EditorVideoOptionsInfo) {
+    public func update(video resource: EditorVideoResource, placeholderImage: UIImage?, options: EditorVideoOptionsInfo) {
         enableDebugLog = options.enableDebugLog
         let checkedOptions = check(resource: resource, options: options)
         let rootViewController = VideoEditorController(resource: resource, placeholderImage: placeholderImage, options: checkedOptions, delegate: self)

--- a/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
@@ -126,7 +126,7 @@ open class ImagePickerController: AnyImageNavigationController {
 
 extension ImagePickerController {
     
-    open func update(options: PickerOptionsInfo) {
+    public func update(options: PickerOptionsInfo) {
         guard viewControllers.isEmpty || enableForceUpdate else {
             return
         }


### PR DESCRIPTION
Hi,

This PR replaces `open` with `public` to resolve the following compiler warning:

```
Non-'@objc' instance method in extensions cannot be overridden; use 'public' instead
```